### PR TITLE
Fix the rounded corner issue when the layout is RTL.

### DIFF
--- a/Sources/ColorWellKit/Utilities/Path.swift
+++ b/Sources/ColorWellKit/Utilities/Path.swift
@@ -126,7 +126,10 @@ struct Path {
     ) -> Path {
         // flatten the opposite edge to join up with the
         // segment on the other side
-        let flatEdge = segmentType.edge?.opposite
+        var flatEdge = segmentType.edge?.opposite
+        if NSApp.userInterfaceLayoutDirection == .rightToLeft {
+            flatEdge = segmentType.edge
+        }
         return colorWellPath(
             rect: rect,
             controlSize: controlSize,


### PR DESCRIPTION
When the layout is **RTL**, the colorwell will have the following issue:
<img width="285" alt="image" src="https://github.com/user-attachments/assets/7c9fedec-33ac-411a-afe6-2cf93191a315" />
